### PR TITLE
Allow users to set the command to open GtdFiles

### DIFF
--- a/autoload/gtd.vim
+++ b/autoload/gtd.vim
@@ -14,6 +14,14 @@ function! gtd#Init()
 		endif
 		let g:gtd#dir = fnamemodify(g:gtd#dir, ':p')
 
+		if !exists('g:gtd#folder_command')
+			if has('win32')
+				let g:gtd#folder_command = 'explorer.exe'
+			else
+				let g:gtd#folder_command = 'xdg-open'
+			endif
+		endif
+
 		if !exists('g:gtd#debug') || g:gtd#debug != 1
 			let g:gtd#debug = 0
 		endif

--- a/autoload/gtd/files.vim
+++ b/autoload/gtd/files.vim
@@ -11,11 +11,7 @@ function! gtd#files#Open()
 		endif
 
 		" Browsing directory
-		if has('win32')
-			execute 'silent !explorer.exe' l:gtd_note_dir
-		else
-			execute 'silent !xdg-open' l:gtd_note_dir
-		endif
+		execute 'silent !'.g:gtd#folder_command.' '.l:gtd_note_dir
 
 		" We wait the user to continue...
 		call input("Hit enter to continue")

--- a/doc/gtd.txt
+++ b/doc/gtd.txt
@@ -168,6 +168,11 @@ plugin insert it as well. >
 Directory where to save notes or to do the searches. Default is '~/notes'. >
 	let g:gtd#dir = '~/notes'
 <
+						*g:gtd#folder_command*
+Command to run to open the folder for :GtdFiles. Default is 'explorer.exe'.
+for Windows and 'xdg-open' for other. >
+	let g:gtd#folder_command = 'ranger'
+<
 						*g:gtd#folding*
 Gtd.vim is able to fold your chapters on each title. See |gtd-syntax|. To
 activate this, you have to let this setting. >


### PR DESCRIPTION
It's probable if not likely that users would want to be able to customize the command that opens the folder for `:GtdFiles`.

For instance, mine is currently `tmux switch-window -h ranger`.