### PR TITLE
Add forced redraw after GtdFiles

### DIFF
--- a/autoload/gtd/files.vim
+++ b/autoload/gtd/files.vim
@@ -29,7 +29,9 @@ function! gtd#files#Open()
 		else
 			throw "Gtd note directory couldn't be found"
 		endif
+		execute "redraw!"
 	catch /.*/
+		execute "redraw!"
 		echomsg v:exception
 	endtry
 


### PR DESCRIPTION
I use `ranger` as my file browser and it redraws the screen itself to work, but that leaves the screen black/ruined. Forcing a redraw after solves the issue.

I also tested the else clause with the throw and it printed the exception after the page clear. I'm not sure how this will behave with the default xdg-open and explorer.exe setup but a) I can't imagine it would break b) I imagine you'll test any PR you're about to merge ;) and c) my setup changing requires effort I'd rather not do right now.