### PR TITLE
Add subprojects using colon separator

### DIFF
--- a/autoload/gtd/search.vim
+++ b/autoload/gtd/search.vim
@@ -248,8 +248,10 @@ function! s:GtdSearchAtom(arg, where)
 		else
 
 			" Preparing search...
-			if index([ '@', '!', '#' ], l:arg_type) >= 0
+			if index([ '@', '!' ], l:arg_type) >= 0
 				let l:arg_reg = '^'.l:arg.'$'
+			elseif index([ '#' ], l:arg_type) >= 0
+				let l:arg_reg = '^'.l:arg.'\(:\|$\)'
 			elseif l:arg_type == '='
 				let l:arg_reg = '^=.*'.strpart(l:arg, 1)
 			elseif l:arg_type == '/'

--- a/autoload/gtd/search.vim
+++ b/autoload/gtd/search.vim
@@ -232,8 +232,10 @@ function! s:GtdSearchAtom(arg, where)
 		let l:gtd_file = g:gtd#dir.l:gtd_name.'.gtd'
 
 		if l:cache_decision
-			if index([ '@', '!', '#' ], l:arg_type) >= 0
+			if index([ '@', '!' ], l:arg_type) >= 0
 				let l:arg_reg = '^'.l:arg.'$'
+			elseif l:arg_type == '#'
+				let l:arg_reg = '^'.l:arg.'\(:.\+\)\=$'
 			elseif l:arg_type == '[*]'
 				let l:arg_reg = '^\[\*\]$'
 			endif
@@ -250,8 +252,8 @@ function! s:GtdSearchAtom(arg, where)
 			" Preparing search...
 			if index([ '@', '!' ], l:arg_type) >= 0
 				let l:arg_reg = '^'.l:arg.'$'
-			elseif index([ '#' ], l:arg_type) >= 0
-				let l:arg_reg = '^'.l:arg.'\(:\|$\)'
+			elseif l:arg_type == '#'
+				let l:arg_reg = '^'.l:arg.'\(:.\+\)\=$'
 			elseif l:arg_type == '='
 				let l:arg_reg = '^=.*'.strpart(l:arg, 1)
 			elseif l:arg_type == '/'

--- a/doc/gtd.txt
+++ b/doc/gtd.txt
@@ -81,6 +81,9 @@ be used to create logical baskets for your tasks. Use what you prefer.
 						*gtd-hashtag*
 You can add a bunch of hashtags to your Gtd files to mark they are related to
 some peculiar concepts or people.
+
+Sub-hashtags can be created using colons, i.e #company-name:project-name, and
+searches will match #company-name and #company-name:project-name.
 	Eg.	#john-doe
 		#project-name
 		#company-name
@@ -273,7 +276,9 @@ and wait for the first empty line before leaving the search. >
 		      year, month and day.
 		    - |gtd-content| to look for a |pattern| into your notes.
 		      Eg: /bar
-		    - |gtd-hashtag|. Eg. #meeting or #jean-marc
+		    - |gtd-hashtag|. Eg. #meeting or #jean-marc. Sub-hashtags
+                      can be matched using #school:math or #school:history
+                      which can be searched using the atom #school.
 
 		    After the first character which is a leader allowing to
 		    know what kind of atom you're looking for, atom can

--- a/doc/gtd.txt
+++ b/doc/gtd.txt
@@ -81,12 +81,12 @@ be used to create logical baskets for your tasks. Use what you prefer.
 						*gtd-hashtag*
 You can add a bunch of hashtags to your Gtd files to mark they are related to
 some peculiar concepts or people.
-
-Sub-hashtags can be created using colons, i.e #company-name:project-name, and
-searches will match #company-name and #company-name:project-name.
 	Eg.	#john-doe
 		#project-name
 		#company-name
+
+Sub-hashtags can be created using colons, i.e #company-name:project-name, and
+searches will match #company-name and #company-name:project-name.
 
 						*gtd-date*
 The creation date of your notes will be known thanks to the automatic filename
@@ -276,9 +276,7 @@ and wait for the first empty line before leaving the search. >
 		      year, month and day.
 		    - |gtd-content| to look for a |pattern| into your notes.
 		      Eg: /bar
-		    - |gtd-hashtag|. Eg. #meeting or #jean-marc. Sub-hashtags
-                      can be matched using #school:math or #school:history
-                      which can be searched using the atom #school.
+		    - |gtd-hashtag|. Eg. #meeting or #jean-marc.
 
 		    After the first character which is a leader allowing to
 		    know what kind of atom you're looking for, atom can
@@ -542,6 +540,7 @@ You can check for updates or browse the plugin here:
 ==============================================================================
 8. Changelog					*gtd-changelog*
 
+	+ Feat: sub-hastags are handled.
 	+ Fix: Deletion of a |gtd-note| could lead to try the deletion of a
 	  non existing cache.
 	+ Allow users to set the command to open |:GtdFiles| with


### PR DESCRIPTION
Let's you specify things like `#memes:reddit` and `#memes:4chan` so that when you search for `#memes` it will show both.

No idea if you want this, but I've been using it.